### PR TITLE
Add route counter, lat & lon to circle popup

### DIFF
--- a/index.php
+++ b/index.php
@@ -1627,7 +1627,6 @@ function importCircles(instanceName = null, color = '#1090fa') {
       circleData.forEach(function(item) {
         if ($('#instanceMode').is(':checked')) {
           newCircle = L.circle(item, {
-            route_counter: circle_route_counter,
             color: '#b410fa',
             fillOpacity: 0.4,
             draggable: false,

--- a/index.php
+++ b/index.php
@@ -1695,7 +1695,7 @@ function importCircles(instanceName = null, color = '#1090fa') {
 }
 
 function getCircleHtml(instance_name, layer, subs) {
-  const htmlString = '<div class="input-group mb-3"><label class="form-check-label">' + instance_name + '<br>Circle ID: ' + layer._leaflet_id + '<br>Route Counter: ' + layer.options.route_counter + '<br>lat,lon: ' + layer._latlng.lat + ',' + layer._latlng.lng + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+  const htmlString = '<div class="input-group mb-3"><label class="form-check-label">' + instance_name + '<br>Circle ID: ' + layer._leaflet_id + '<br>Circle Counter: ' + layer.options.route_counter + '<br>lat,lon: ' + layer._latlng.lat + ',' + layer._latlng.lng + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
   return htmlString
 }
 

--- a/index.php
+++ b/index.php
@@ -1508,7 +1508,7 @@ function getInstance(instanceName = null, color = '#1090fa') {
                   radius: radius,
                   instanceID: instance.id
                 }).bindPopup(function (layer) {
-                  return '<div class="input-group mb-3"><label class="form-check-label">' + instanceName + '<br>Circle ID: ' + layer._leaflet_id + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+                  return getCircleHtml(instanceName, layer, subs);
                 }).addTo(instanceLayer);
                 instance.push(newCircle._leaflet_id);
               }              
@@ -1545,7 +1545,7 @@ function getInstance(instanceName = null, color = '#1090fa') {
                   radius: radius,
                   instanceID: instance.id
                 }).bindPopup(function (layer) {
-                  return '<div class="input-group mb-3"><label class="form-check-label">' + instanceName + '<br>Circle ID: ' + layer._leaflet_id + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+                  return getCircleHtml(instanceName, layer, subs);
                 }).addTo(instanceLayer);
                 instance.push(newCircle._leaflet_id);
               }
@@ -1621,11 +1621,13 @@ function importCircles(instanceName = null, color = '#1090fa') {
         radius = settings.circleSize;
       }
       let instance = [];
+      let circle_route_counter = 1;
       instance.name = instanceName;
       instance.id = instances.length;
       circleData.forEach(function(item) {
         if ($('#instanceMode').is(':checked')) {
           newCircle = L.circle(item, {
+            route_counter: circle_route_counter,
             color: '#b410fa',
             fillOpacity: 0.4,
             draggable: false,
@@ -1633,16 +1635,18 @@ function importCircles(instanceName = null, color = '#1090fa') {
           }).addTo(bgLayer);
         } else {
           newCircle = L.circle(item, {
+            route_counter: circle_route_counter,
             color: color,
             fillOpacity: 0.2,
             draggable: true,
             radius: radius,
             instanceID: instance.id
           }).bindPopup(function (layer) {
-            return '<div class="input-group mb-3"><label class="form-check-label">' + instanceName + '<br>Circle ID: ' + layer._leaflet_id + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+            return getCircleHtml(instanceName, layer, subs);
           }).addTo(instanceLayer);
           instance.push(newCircle._leaflet_id);
-        }              
+        }
+        circle_route_counter += 1;
       });
       instances.push(instance);
       drawRoute(instance);
@@ -1688,6 +1692,11 @@ function importCircles(instanceName = null, color = '#1090fa') {
       drawRoute(instance);
     }
   }
+}
+
+function getCircleHtml(instance_name, layer, subs) {
+  const htmlString = '<div class="input-group mb-3"><label class="form-check-label">' + instance_name + '<br>Circle ID: ' + layer._leaflet_id + '<br>Route Counter: ' + layer.options.route_counter + '<br>lat,lon: ' + layer._latlng.lat + ',' + layer._latlng.lng + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+  return htmlString
 }
 
 function generateOptimizedRoute(optimizeForGyms, optimizeForPokestops, optimizeForSpawnpoints, optimizeForUnknownSpawnpoints, optimizeNests, optimizePolygons, optimizeCircles) {
@@ -2632,7 +2641,7 @@ $(document).ready(function() {
           radius: radius,
           instanceID: instance.id
         }).bindPopup(function (layer) {
-          return '<div class="input-group mb-3"><label class="form-check-label">' + instance.name + '<br>Circle ID: ' + layer._leaflet_id + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+          return getCircleHtml(instance.name, layer, subs);
         }).addTo(instanceLayer);
         sourceLayer.removeLayer(parseInt(item._leaflet_id));
         instance.push(circle._leaflet_id);
@@ -2682,7 +2691,7 @@ $(document).ready(function() {
             radius: radius,
             instanceID: newInstance.id
           }).bindPopup(function (layer) {
-            return '<div class="input-group mb-3"><label class="form-check-label">' + newInstance.name + '<br>Circle ID: ' + layer._leaflet_id + '</label></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm deleteLayer" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.delete + '</button></div><div class="input-group mb-3"><button class="btn btn-secondary btn-sm sortInstance" data-layer-container="instanceLayer" data-layer-id=' + layer._leaflet_id + ' type="button">' + subs.newRoute + '</button></div>';
+            return getCircleHtml(newInstance.name, layer, subs);
           }).addTo(instanceLayer);
           newInstance.push(newCircle._leaflet_id);              
         });


### PR DESCRIPTION
Changes:
- Added ~route~ circle counter (those will be `undefined` unless imported using `Own coordinates`)
- Added lat, lon
- Cleanup: Reused circle popup html string

TODO:
- Remove circle counter from the places it's not needed

Example:
![2020-11-07_02-20-02-firefox](https://user-images.githubusercontent.com/10072920/98428090-302c5500-20a0-11eb-85fb-bdea3db823d2.png)

Leaving it, as someone might find it useful.
