### PR TITLE
Support for config from Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /var/www/html/
 COPY ./css/* /var/www/html/css/
 COPY ./other/* /var/www/html/other/
 COPY ./index.php /var/www/html/
+COPY ./config/config.env.php /var/www/html/config/config.php
 #COPY ./.htaccess.example /var/www/html/.htaccess
 RUN docker-php-ext-install pdo pdo_mysql

--- a/config/config.env.php
+++ b/config/config.env.php
@@ -1,11 +1,11 @@
 <?php
 
 //Configuration options
-define('DB_HOST', getenv("DB_HOST") ?? "127.0.0.1");
-define('DB_USER', getenv("DB_USER") ?? "rdmuser");
-define('DB_PSWD', getenv("DB_PSWD") ?? "password");
-define('DB_NAME', getenv("DB_NAME") ?? "rdmdb");
-define('DB_PORT', getenv("DB_PORT") ?? 3306);
-define('OWN_TS', getenv("OWN_TS") ?? "https://IP:PORT/tile/STYLE/{z}/{x}/{y}/1/png");
+define('DB_HOST', getenv("DB_HOST") ?: "127.0.0.1");
+define('DB_USER', getenv("DB_USER") ?: "rdmuser");
+define('DB_PSWD', getenv("DB_PSWD") ?: "password");
+define('DB_NAME', getenv("DB_NAME") ?: "rdmdb");
+define('DB_PORT', getenv("DB_PORT") ?: 3306);
+define('OWN_TS', getenv("OWN_TS") ?: "https://IP:PORT/tile/STYLE/{z}/{x}/{y}/1/png");
 
 ?>

--- a/config/config.env.php
+++ b/config/config.env.php
@@ -1,0 +1,11 @@
+<?php
+
+//Configuration options
+define('DB_HOST', getenv("DB_HOST") ?? "127.0.0.1");
+define('DB_USER', getenv("DB_USER") ?? "rdmuser");
+define('DB_PSWD', getenv("DB_PSWD") ?? "password");
+define('DB_NAME', getenv("DB_NAME") ?? "rdmdb");
+define('DB_PORT', getenv("DB_PORT") ?? 3306);
+define('OWN_TS', getenv("OWN_TS") ?? "https://IP:PORT/tile/STYLE/{z}/{x}/{y}/1/png");
+
+?>


### PR DESCRIPTION
- adds a `config.env.php` that uses env variables for settings
- uses that `config.env.php` as default `config.php` so only env variables need to be set and no volume mounting is required